### PR TITLE
Fix makefile run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	docker build -t hmcts/cnp-java-base .
 
 run:
-	docker run -it --rm hmcts/cnp-java-base:latest sh
+	docker run --entrypoint "/bin/sh" -it --rm hmcts/cnp-java-base:latest
 
 debian:
 	docker build -f Dockerfile.debian -t hmcts/cnp-java-base:debian .


### PR DESCRIPTION
Previously was getting:
```
$ make run
docker run -it --rm hmcts/cnp-java-base:latest sh
Error: Unable to access jarfile sh
make: *** [run] Error 1
```