### PR TITLE
Fix hmcts home dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
 .DEFAULT=build
 
 build-8:
-	docker build --build-arg version=8 -t base/java:openjdk-8-distroless-1.2 distroless/
+	docker build --build-arg version=8 -t base/java:openjdk-8-distroless-1.3 distroless/
 
 build-8-debug:
-	docker build --build-arg version=8-debug -t base/java:openjdk-8-distroless-debug-1.2 -f distroless/debug.Dockerfile distroless/
+	docker build --build-arg version=8-debug -t base/java:openjdk-8-distroless-debug-1.3 -f distroless/debug.Dockerfile distroless/
 
 build-11:
-	docker build --build-arg version=11 -t base/java:openjdk-11-distroless-1.2 distroless/
+	docker build --build-arg version=11 -t base/java:openjdk-11-distroless-1.3 distroless/
 
 build-11-debug:
-	docker build --build-arg version=11-debug -t base/java:openjdk-11-distroless-debug-1.2 -f distroless/debug.Dockerfile distroless/
+	docker build --build-arg version=11-debug -t base/java:openjdk-11-distroless-debug-1.3 -f distroless/debug.Dockerfile distroless/
 
 run-8-debug:
-	docker run --entrypoint sh -it --rm base/java:openjdk-11-distroless-debug-1.2
+	docker run --entrypoint sh -it --rm base/java:openjdk-11-distroless-debug-1.3
 
 run-11-debug:
-	docker run --entrypoint sh -it --rm base/java:openjdk-11-distroless-debug-1.2
+	docker run --entrypoint sh -it --rm base/java:openjdk-11-distroless-debug-1.3
 
 build-all: build-8 build-8-debug build-11 build-11-debug

--- a/distroless/passwd
+++ b/distroless/passwd
@@ -1,3 +1,3 @@
 root:x:0:0:root:/home:/sbin/nologin
 nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin
-hmcts:x:1000:1000:hmcts:/home:/sbin/nologin
+hmcts:x:1000:1000:hmcts:/opt/app:/sbin/nologin


### PR DESCRIPTION
### JIRA link (if applicable) ###

[[AB#591](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/591)]

### Change description ###

Currently root and hmcts share a home dir. This causes issues with permissions

Exception in thread "main" java.lang.RuntimeException: Could not create parent directory for lock file /home/.gradle/wrapper/dists/gradle-5.5.1-all/8yl0syll3fr5m1v472nzznadi/gradle-5.5.1-all.zip.lck

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
