### PR TITLE
DTSPO-26450 - migration of keepalive-workflow to gh-workflow-keepalive

### DIFF
--- a/.github/workflows/keep_alive.yml
+++ b/.github/workflows/keep_alive.yml
@@ -9,7 +9,8 @@ jobs:
   keepalive:
     name: Keep scheduled jobs running
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
-      - uses: actions/checkout@v4
-      - name: 'reset keepalive timer'
-        uses: gautamkrishnar/keepalive-workflow@v2
+      - name: 'Keep workflows alive'
+        uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-26450

### Change description

This PR updates the keepalive workflow to use `liskin/gh-workflow-keepalive@v1`, replacing the previously used (now suspended) `gautamkrishnar/keepalive-workflow@v2` action.

**Why?**

- The `gautamkrishnar/keepalive-workflow@v2` action has been suspended by GitHub due to the maintainer's account suspension, causing our keepalive workflows to fail completely.
- This workflow is critical for preventing GitHub from automatically disabling our scheduled workflows (like sandbox cleanup) after 60 days of repository inactivity.

**How the new changes work?**
- The new action is actively maintained, uses the GitHub API (no dummy commits), and requires only minimal permissions (actions: write).
- The `liskin/gh-workflow-keepalive@v1` action works by making a GitHub API call to "enable" the workflow file it is running in.
- By running on a schedule (e.g., daily), it resets the inactivity timer for scheduled workflows in the repository.
- Keeps repository history clean and improves security.


### Testing done

The updated workflow was tested on a temporary branch by triggering it manually via the GitHub Actions tab. The workflow completed successfully with no errors, confirming that the new `liskin/gh-workflow-keepalive@v1 `action works as expected and keeps scheduled workflows active. 
Workflow now working as expected:
<img width="2578" height="1182" alt="image" src="https://github.com/user-attachments/assets/47debc7d-c1c3-4d74-8d68-795aee5f4a4d" />


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
